### PR TITLE
Cleanup namespace + usings

### DIFF
--- a/Godot.Logging/FormatRule.cs
+++ b/Godot.Logging/FormatRule.cs
@@ -1,55 +1,54 @@
 using System.Text;
 
-namespace Godot.Logging
+namespace Godot.Logging;
+
+public static class ColorExtensions
 {
-    public static class ColorExtensions
+    public static string ToHexArgb(this Color color)
     {
-        public static string ToHexArgb(this Color color)
-        {
-            var builder = new StringBuilder();
-            builder.Append("#");
-            builder.Append(color.A8.ToString("X2"));
-            builder.Append(color.R8.ToString("X2"));
-            builder.Append(color.G8.ToString("X2"));
-            builder.Append(color.B8.ToString("X2"));
-            return builder.ToString();
-        }
+        var builder = new StringBuilder();
+        builder.Append("#");
+        builder.Append(color.A8.ToString("X2"));
+        builder.Append(color.R8.ToString("X2"));
+        builder.Append(color.G8.ToString("X2"));
+        builder.Append(color.B8.ToString("X2"));
+        return builder.ToString();
+    }
+}
+
+public class FormatRule
+{
+    /// <summary>
+    /// Color to associate with the log event if the target supports color.
+    /// </summary>
+    public Color TextColor
+    {
+        get;
+        set;
+    } = Colors.White;
+
+    /// <summary>
+    /// Text code indicating the format to use to write the log event.
+    /// </summary>
+    public string FormatText
+    {
+        get;
+        set;
     }
 
-    public class FormatRule
+    /// <summary>
+    /// Log level to associate the Format Rule with.
+    /// </summary>
+    public LogLevel FormatLogLevel
     {
-        /// <summary>
-        /// Color to associate with the log event if the target supports color.
-        /// </summary>
-        public Color TextColor
-        {
-            get;
-            set;
-        } = Colors.White;
+        get;
+        set;
+    }
 
-        /// <summary>
-        /// Text code indicating the format to use to write the log event.
-        /// </summary>
-        public string FormatText
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Log level to associate the Format Rule with.
-        /// </summary>
-        public LogLevel FormatLogLevel
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        ///  Default constructor.
-        /// </summary>
-        public FormatRule()
-        {
-        }
+    /// <summary>
+    ///  Default constructor.
+    /// </summary>
+    public FormatRule()
+    {
     }
 }

--- a/Godot.Logging/FormatRule.cs
+++ b/Godot.Logging/FormatRule.cs
@@ -1,6 +1,6 @@
-using System.Text;
-
 namespace Godot.Logging;
+
+using System.Text;
 
 public static class ColorExtensions
 {

--- a/Godot.Logging/Godot.Logging.csproj
+++ b/Godot.Logging/Godot.Logging.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Godot.NET.Sdk/4.0.2">
+﻿<Project Sdk="Godot.NET.Sdk/4.0.2">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <RootNamespace>Godot.Logging</RootNamespace>
     <AssemblyVersion>1.1.0.0</AssemblyVersion>

--- a/Godot.Logging/GodotLogger.cs
+++ b/Godot.Logging/GodotLogger.cs
@@ -1,138 +1,137 @@
 using System.Diagnostics;
 
-namespace Godot.Logging
+namespace Godot.Logging;
+
+/// <summary>
+/// The logger singleton. Used to record log
+/// entries to the game's log.
+/// </summary>
+public sealed class GodotLogger
 {
-    /// <summary>
-    /// The logger singleton. Used to record log
-    /// entries to the game's log.
-    /// </summary>
-    public sealed class GodotLogger
+    #region Singleton Instance
+    private static readonly GodotLogger instance = new GodotLogger();
+
+    static GodotLogger()
     {
-        #region Singleton Instance
-        private static readonly GodotLogger instance = new GodotLogger();
+    }
 
-        static GodotLogger()
-        {
-        }
+    private GodotLogger()
+    {
+    }
 
-        private GodotLogger()
-        {
-        }
+    public static GodotLogger Instance
+    {
+        get => instance;
+    }
+    #endregion
 
-        public static GodotLogger Instance
-        {
-            get => instance;
-        }
-        #endregion
+    #region Static API
+    /// <summary>
+    /// Sets the configuration for the <see cref="GodotLogger"/>.
+    /// </summary>
+    /// <param name="config">The log configuration.</param>
+    public static void SetConfiguration(LogConfiguration config)
+    {
+        Instance.Configuration = config;
+    }
 
-        #region Static API
-        /// <summary>
-        /// Sets the configuration for the <see cref="GodotLogger"/>.
-        /// </summary>
-        /// <param name="config">The log configuration.</param>
-        public static void SetConfiguration(LogConfiguration config)
-        {
-            Instance.Configuration = config;
-        }
-
-        /// <summary>
-        /// Logs a debug message.
-        /// </summary>
-        /// <param name="message">The debug message to log.</param>
-        public static void LogDebug(object message)
-        {
+    /// <summary>
+    /// Logs a debug message.
+    /// </summary>
+    /// <param name="message">The debug message to log.</param>
+    public static void LogDebug(object message)
+    {
 #if DEBUG
-            Instance.Log(LogLevel.Debug, message);
+        Instance.Log(LogLevel.Debug, message);
 #endif
-        }
+    }
 
-        /// <summary>
-        /// Logs an informative message.
-        /// </summary>
-        /// <param name="message">The message to log.</param>
-        public static void LogInfo(object message)
+    /// <summary>
+    /// Logs an informative message.
+    /// </summary>
+    /// <param name="message">The message to log.</param>
+    public static void LogInfo(object message)
+    {
+        Instance.Log(LogLevel.Info, message);
+    }
+
+    /// <summary>
+    /// Logs a command message. Typically used to echo user-entered commands
+    /// from a game's command line console.
+    /// </summary>
+    /// <param name="message">The command message.</param>
+    public static void LogCommand(object message)
+    {
+        Instance.Log(LogLevel.Command, message);
+    }
+
+    /// <summary>
+    /// Logs a warning message.
+    /// </summary>
+    /// <param name="message">The warning message to log.</param>
+    public static void LogWarning(object message)
+    {
+        Instance.Log(LogLevel.Warn, message);
+    }
+
+    /// <summary>
+    /// Logs an error message.
+    /// </summary>
+    /// <param name="message">The error message to log.</param>
+    public static void LogError(object message)
+    {
+        Instance.Log(LogLevel.Error, message);
+    }
+    #endregion
+
+    /// <summary>
+    /// The configuration used by the logger.
+    /// </summary>
+    public LogConfiguration Configuration
+    {
+        get;
+        set;
+    }
+
+    /// <summary>
+    /// Adds an entry to the log at the given <see cref="LogLevel"/>.
+    /// </summary>
+    /// <param name="logLevel">Log level to record the entry at.</param>
+    /// <param name="message">The log entry message.</param>
+    public void Log(LogLevel logLevel, object message)
+    {
+        var logEvent = CreateLogEvent();
+        logEvent.Message = message.ToString();
+
+        foreach (var target in Configuration.Targets)
+            target.Write(logLevel, logEvent);
+
+        if (logLevel == LogLevel.Error)
+            GD.PushError(logEvent.Message);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="LogEventInfo"/> using the current call stack.
+    /// </summary>
+    /// <returns>An initialized <see cref="LogEventInfo"/> without the message.</returns>
+    private LogEventInfo CreateLogEvent()
+    {
+        LogEventInfo logEvent = new LogEventInfo();
+
+        for (int frameIndex = 1; frameIndex <= 5; frameIndex++)
         {
-            Instance.Log(LogLevel.Info, message);
-        }
+            var frame = new StackFrame(frameIndex);
+            var method = frame.GetMethod();
+            var declaringType = method.DeclaringType;
 
-        /// <summary>
-        /// Logs a command message. Typically used to echo user-entered commands
-        /// from a game's command line console.
-        /// </summary>
-        /// <param name="message">The command message.</param>
-        public static void LogCommand(object message)
-        {
-            Instance.Log(LogLevel.Command, message);
-        }
-
-        /// <summary>
-        /// Logs a warning message.
-        /// </summary>
-        /// <param name="message">The warning message to log.</param>
-        public static void LogWarning(object message)
-        {
-            Instance.Log(LogLevel.Warn, message);
-        }
-
-        /// <summary>
-        /// Logs an error message.
-        /// </summary>
-        /// <param name="message">The error message to log.</param>
-        public static void LogError(object message)
-        {
-            Instance.Log(LogLevel.Error, message);
-        }
-        #endregion
-
-        /// <summary>
-        /// The configuration used by the logger.
-        /// </summary>
-        public LogConfiguration Configuration
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Adds an entry to the log at the given <see cref="LogLevel"/>.
-        /// </summary>
-        /// <param name="logLevel">Log level to record the entry at.</param>
-        /// <param name="message">The log entry message.</param>
-        public void Log(LogLevel logLevel, object message)
-        {
-            var logEvent = CreateLogEvent();
-            logEvent.Message = message.ToString();
-
-            foreach (var target in Configuration.Targets)
-                target.Write(logLevel, logEvent);
-
-            if (logLevel == LogLevel.Error)
-                GD.PushError(logEvent.Message);
-        }
-
-        /// <summary>
-        /// Creates a <see cref="LogEventInfo"/> using the current call stack.
-        /// </summary>
-        /// <returns>An initialized <see cref="LogEventInfo"/> without the message.</returns>
-        private LogEventInfo CreateLogEvent()
-        {
-            LogEventInfo logEvent = new LogEventInfo();
-
-            for (int frameIndex = 1; frameIndex <= 5; frameIndex++)
+            if (declaringType != typeof(GodotLogger))
             {
-                var frame = new StackFrame(frameIndex);
-                var method = frame.GetMethod();
-                var declaringType = method.DeclaringType;
-
-                if (declaringType != typeof(GodotLogger))
-                {
-                    logEvent.MethodName = method.Name;
-                    logEvent.ClassName = declaringType.Name;
-                    break;
-                }
+                logEvent.MethodName = method.Name;
+                logEvent.ClassName = declaringType.Name;
+                break;
             }
-
-            return logEvent;
         }
+
+        return logEvent;
     }
 }

--- a/Godot.Logging/GodotLogger.cs
+++ b/Godot.Logging/GodotLogger.cs
@@ -1,6 +1,6 @@
-using System.Diagnostics;
-
 namespace Godot.Logging;
+
+using System.Diagnostics;
 
 /// <summary>
 /// The logger singleton. Used to record log

--- a/Godot.Logging/LogConfiguration.cs
+++ b/Godot.Logging/LogConfiguration.cs
@@ -1,8 +1,8 @@
+namespace Godot.Logging;
+
 using Godot.Logging.Targets;
 using System;
 using System.Collections.Generic;
-
-namespace Godot.Logging;
 
 /// <summary>
 /// Configuration for the logger.

--- a/Godot.Logging/LogConfiguration.cs
+++ b/Godot.Logging/LogConfiguration.cs
@@ -2,145 +2,144 @@ using Godot.Logging.Targets;
 using System;
 using System.Collections.Generic;
 
-namespace Godot.Logging
+namespace Godot.Logging;
+
+/// <summary>
+/// Configuration for the logger.
+/// </summary>
+public class LogConfiguration
 {
+    private Dictionary<string, LogTarget> targets;
+    private Dictionary<LogLevel, FormatRule> formattingRules;
+
     /// <summary>
-    /// Configuration for the logger.
+    /// Rules used for formatting log entries.
     /// </summary>
-    public class LogConfiguration
+    public IEnumerable<FormatRule> FormattingRules
     {
-        private Dictionary<string, LogTarget> targets;
-        private Dictionary<LogLevel, FormatRule> formattingRules;
+        get => formattingRules.Values;
+    }
 
-        /// <summary>
-        /// Rules used for formatting log entries.
-        /// </summary>
-        public IEnumerable<FormatRule> FormattingRules
+    /// <summary>
+    /// Enumerates all currently registered <see cref="LogTarget"/> objects.
+    /// </summary>
+    public IEnumerable<LogTarget> Targets
+    {
+        get => targets.Values;
+    }
+
+    /// <summary>
+    /// Default constructor.
+    /// </summary>
+    public LogConfiguration()
+    {
+        targets = new Dictionary<string, LogTarget>();
+        formattingRules = new Dictionary<LogLevel, FormatRule>();
+
+        FormatRule debugRule = new FormatRule()
         {
-            get => formattingRules.Values;
-        }
+            FormatText = "[${level}][${classname}.${methodname}] ${message}",
+            FormatLogLevel = LogLevel.Debug
+        };
+        ApplyFormattingRule(debugRule);
 
-        /// <summary>
-        /// Enumerates all currently registered <see cref="LogTarget"/> objects.
-        /// </summary>
-        public IEnumerable<LogTarget> Targets
+        FormatRule infoRule = new FormatRule()
         {
-            get => targets.Values;
-        }
+            FormatText = "[${level}][${classname}.${methodname}] ${message}",
+            FormatLogLevel = LogLevel.Info
+        };
+        ApplyFormattingRule(infoRule);
 
-        /// <summary>
-        /// Default constructor.
-        /// </summary>
-        public LogConfiguration()
+        FormatRule cmdRule = new FormatRule()
         {
-            targets = new Dictionary<string, LogTarget>();
-            formattingRules = new Dictionary<LogLevel, FormatRule>();
+            FormatText = "${message}",
+            FormatLogLevel = LogLevel.Command
+        };
+        ApplyFormattingRule(cmdRule);
 
-            FormatRule debugRule = new FormatRule()
+        FormatRule warningRule = new FormatRule()
+        {
+            FormatText = "[${level}][${classname}.${methodname}] ${message}",
+            FormatLogLevel = LogLevel.Warn,
+            TextColor = Colors.Yellow
+        };
+        ApplyFormattingRule(warningRule);
+
+        FormatRule errorRule = new FormatRule()
+        {
+            FormatText = "[${level}][${classname}.${methodname}] ${message}",
+            FormatLogLevel = LogLevel.Error,
+            TextColor = Colors.Red
+        };
+        ApplyFormattingRule(errorRule);
+    }
+
+    /// <summary>
+    /// Applies a formatting rule for the <see cref="LogLevel"/> contained within
+    /// the <see cref="FormatRule"/>.
+    /// </summary>
+    /// <remarks>This operation will overwrite any existing rule for the contained <see cref="LogLevel"/>.</remarks>
+    /// <param name="rule">The rule to apply.</param>
+    public void ApplyFormattingRule(FormatRule rule)
+    {
+        formattingRules[rule.FormatLogLevel] = rule;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="FormatRule"/> for the given <see cref="LogLevel"/>.
+    /// </summary>
+    /// <param name="logLevel">The log level for which to obtain a format for.</param>
+    /// <returns>A format rule.</returns>
+    public FormatRule GetFormat(LogLevel logLevel)
+    {
+        return formattingRules[logLevel];
+    }
+
+    /// <summary>
+    /// Gets a <see cref="LogTarget"/> by name.
+    /// </summary>
+    /// <param name="targetName">The name of the target to find.</param>
+    /// <returns>A <see cref="LogTarget"/> referenced by the given name, or null if not found.</returns>
+    public LogTarget GetTarget(string targetName)
+    {
+        if (!targets.ContainsKey(targetName))
+            return null;
+
+        return targets[targetName];
+    }
+
+    /// <summary>
+    /// Gets the first <see cref="LogTarget"/> of a given type.
+    /// </summary>
+    /// <typeparam name="T">The derived <see cref="LogTarget"/> type.</typeparam>
+    /// <returns>A <see cref="LogTarget"/> of the specified derived type, or null if not found.</returns>
+    public T GetTarget<T>() where T : LogTarget
+    {
+        T targetToFind = default;
+        Type typeToFind = typeof(T);
+
+        foreach (var target in Targets)
+        {
+            if (typeToFind.Equals(target.GetType()))
             {
-                FormatText = "[${level}][${classname}.${methodname}] ${message}",
-                FormatLogLevel = LogLevel.Debug
-            };
-            ApplyFormattingRule(debugRule);
-
-            FormatRule infoRule = new FormatRule()
-            {
-                FormatText = "[${level}][${classname}.${methodname}] ${message}",
-                FormatLogLevel = LogLevel.Info
-            };
-            ApplyFormattingRule(infoRule);
-
-            FormatRule cmdRule = new FormatRule()
-            {
-                FormatText = "${message}",
-                FormatLogLevel = LogLevel.Command
-            };
-            ApplyFormattingRule(cmdRule);
-
-            FormatRule warningRule = new FormatRule()
-            {
-                FormatText = "[${level}][${classname}.${methodname}] ${message}",
-                FormatLogLevel = LogLevel.Warn,
-                TextColor = Colors.Yellow
-            };
-            ApplyFormattingRule(warningRule);
-
-            FormatRule errorRule = new FormatRule()
-            {
-                FormatText = "[${level}][${classname}.${methodname}] ${message}",
-                FormatLogLevel = LogLevel.Error,
-                TextColor = Colors.Red
-            };
-            ApplyFormattingRule(errorRule);
-        }
-
-        /// <summary>
-        /// Applies a formatting rule for the <see cref="LogLevel"/> contained within
-        /// the <see cref="FormatRule"/>.
-        /// </summary>
-        /// <remarks>This operation will overwrite any existing rule for the contained <see cref="LogLevel"/>.</remarks>
-        /// <param name="rule">The rule to apply.</param>
-        public void ApplyFormattingRule(FormatRule rule)
-        {
-            formattingRules[rule.FormatLogLevel] = rule;
-        }
-
-        /// <summary>
-        /// Gets the <see cref="FormatRule"/> for the given <see cref="LogLevel"/>.
-        /// </summary>
-        /// <param name="logLevel">The log level for which to obtain a format for.</param>
-        /// <returns>A format rule.</returns>
-        public FormatRule GetFormat(LogLevel logLevel)
-        {
-            return formattingRules[logLevel];
-        }
-
-        /// <summary>
-        /// Gets a <see cref="LogTarget"/> by name.
-        /// </summary>
-        /// <param name="targetName">The name of the target to find.</param>
-        /// <returns>A <see cref="LogTarget"/> referenced by the given name, or null if not found.</returns>
-        public LogTarget GetTarget(string targetName)
-        {
-            if (!targets.ContainsKey(targetName))
-                return null;
-
-            return targets[targetName];
-        }
-
-        /// <summary>
-        /// Gets the first <see cref="LogTarget"/> of a given type.
-        /// </summary>
-        /// <typeparam name="T">The derived <see cref="LogTarget"/> type.</typeparam>
-        /// <returns>A <see cref="LogTarget"/> of the specified derived type, or null if not found.</returns>
-        public T GetTarget<T>() where T : LogTarget
-        {
-            T targetToFind = default;
-            Type typeToFind = typeof(T);
-
-            foreach (var target in Targets)
-            {
-                if (typeToFind.Equals(target.GetType()))
-                {
-                    targetToFind = (T)target;
-                    break;
-                }
+                targetToFind = (T)target;
+                break;
             }
-
-            return targetToFind;
         }
 
-        /// <summary>
-        /// Registers a <see cref="LogTarget"/> with the <see cref="LogConfiguration"/>.
-        /// </summary>
-        /// <param name="target">The <see cref="LogTarget"/> to register.</param>
-        public void RegisterTarget(LogTarget target)
-        {
-            if (targets.ContainsKey(target.Name))
-                throw new InvalidOperationException("LogTarget by the name of " + target.Name + " has already been registered with this configuration.");
+        return targetToFind;
+    }
 
-            target.SetConfiguration(this);
-            targets.Add(target.Name, target);
-        }
+    /// <summary>
+    /// Registers a <see cref="LogTarget"/> with the <see cref="LogConfiguration"/>.
+    /// </summary>
+    /// <param name="target">The <see cref="LogTarget"/> to register.</param>
+    public void RegisterTarget(LogTarget target)
+    {
+        if (targets.ContainsKey(target.Name))
+            throw new InvalidOperationException("LogTarget by the name of " + target.Name + " has already been registered with this configuration.");
+
+        target.SetConfiguration(this);
+        targets.Add(target.Name, target);
     }
 }

--- a/Godot.Logging/LogEventInfo.cs
+++ b/Godot.Logging/LogEventInfo.cs
@@ -1,65 +1,64 @@
-namespace Godot.Logging
+namespace Godot.Logging;
+
+/// <summary>
+/// Contains information about a log event.
+/// </summary>
+public class LogEventInfo
 {
     /// <summary>
-    /// Contains information about a log event.
+    /// The type name of the class from which the log event was triggered.
     /// </summary>
-    public class LogEventInfo
+    public string ClassName
     {
-        /// <summary>
-        /// The type name of the class from which the log event was triggered.
-        /// </summary>
-        public string ClassName
-        {
-            get;
-            internal set;
-        } = string.Empty;
+        get;
+        internal set;
+    } = string.Empty;
 
-        /// <summary>
-        /// The method name from which the log event was triggered.
-        /// </summary>
-        public string MethodName
-        {
-            get;
-            internal set;
-        } = string.Empty;
+    /// <summary>
+    /// The method name from which the log event was triggered.
+    /// </summary>
+    public string MethodName
+    {
+        get;
+        internal set;
+    } = string.Empty;
 
-        /// <summary>
-        /// The message to be logged.
-        /// </summary>
-        public string Message
-        {
-            get;
-            internal set;
-        } = string.Empty;
+    /// <summary>
+    /// The message to be logged.
+    /// </summary>
+    public string Message
+    {
+        get;
+        internal set;
+    } = string.Empty;
 
-        /// <summary>
-        /// Default constructor.
-        /// </summary>
-        public LogEventInfo()
-        {
+    /// <summary>
+    /// Default constructor.
+    /// </summary>
+    public LogEventInfo()
+    {
 
-        }
+    }
 
-        /// <summary>
-        /// Constructor which takes the log message.
-        /// </summary>
-        /// <param name="message">The message to log.</param>
-        public LogEventInfo(string message)
-        {
-            Message = message;
-        }
+    /// <summary>
+    /// Constructor which takes the log message.
+    /// </summary>
+    /// <param name="message">The message to log.</param>
+    public LogEventInfo(string message)
+    {
+        Message = message;
+    }
 
-        /// <summary>
-        /// Constructor which takes the log message, class name and method name.
-        /// </summary>
-        /// <param name="message">The message to log.</param>
-        /// <param name="className">The name of the class from which the event originated.</param>
-        /// <param name="methodName">The name of the method from which the event originated.</param>
-        public LogEventInfo(string message, string className, string methodName)
-        {
-            Message = message;
-            ClassName = className;
-            MethodName = methodName;
-        }
+    /// <summary>
+    /// Constructor which takes the log message, class name and method name.
+    /// </summary>
+    /// <param name="message">The message to log.</param>
+    /// <param name="className">The name of the class from which the event originated.</param>
+    /// <param name="methodName">The name of the method from which the event originated.</param>
+    public LogEventInfo(string message, string className, string methodName)
+    {
+        Message = message;
+        ClassName = className;
+        MethodName = methodName;
     }
 }

--- a/Godot.Logging/LogLevel.cs
+++ b/Godot.Logging/LogLevel.cs
@@ -1,14 +1,13 @@
-namespace Godot.Logging
+namespace Godot.Logging;
+
+/// <summary>
+/// Enumeration for a log entry's level or category.
+/// </summary>
+public enum LogLevel
 {
-    /// <summary>
-    /// Enumeration for a log entry's level or category.
-    /// </summary>
-    public enum LogLevel
-    {
-        Debug,
-        Info,
-        Warn,
-        Error,
-        Command
-    }
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Command
 }

--- a/Godot.Logging/Targets/BBTextTarget.cs
+++ b/Godot.Logging/Targets/BBTextTarget.cs
@@ -1,6 +1,6 @@
-using System.Text;
-
 namespace Godot.Logging.Targets;
+
+using System.Text;
 
 public class BBTextTarget : MemoryTarget
 {

--- a/Godot.Logging/Targets/BBTextTarget.cs
+++ b/Godot.Logging/Targets/BBTextTarget.cs
@@ -1,46 +1,45 @@
 using System.Text;
 
-namespace Godot.Logging.Targets
+namespace Godot.Logging.Targets;
+
+public class BBTextTarget : MemoryTarget
 {
-    public class BBTextTarget : MemoryTarget
+    /// <summary>
+    /// Default constructor for a <see cref="BBTextTarget"/>.
+    /// </summary>
+    /// <param name="name">The name to give the target within the logging system.</param>
+    public BBTextTarget(string name) : base(name)
     {
-        /// <summary>
-        /// Default constructor for a <see cref="BBTextTarget"/>.
-        /// </summary>
-        /// <param name="name">The name to give the target within the logging system.</param>
-        public BBTextTarget(string name) : base(name)
-        {
-        }
+    }
 
-        /// <summary>
-        /// Constructor for a <see cref="BBTextTarget"/> that allows setting
-        /// the size of the buffer (in lines).
-        /// </summary>
-        /// <param name="name">The name to give the target within the logging system.</param>
-        /// <param name="bufferSize">The number log entries to be kept in memory.</param>
-        public BBTextTarget(string name, int bufferSize) : base(name)
-        {
-        }
+    /// <summary>
+    /// Constructor for a <see cref="BBTextTarget"/> that allows setting
+    /// the size of the buffer (in lines).
+    /// </summary>
+    /// <param name="name">The name to give the target within the logging system.</param>
+    /// <param name="bufferSize">The number log entries to be kept in memory.</param>
+    public BBTextTarget(string name, int bufferSize) : base(name)
+    {
+    }
 
-        /// <summary>
-        /// Writes a log event to the <see cref="LogTarget"/>.
-        /// </summary>
-        /// <param name="logLevel">The level/severity of the log event.</param>
-        /// <param name="logEvent">The log event.</param>
-        public override void Write(LogLevel logLevel, LogEventInfo logEvent)
-        {
-            base.Write(logLevel, logEvent);
+    /// <summary>
+    /// Writes a log event to the <see cref="LogTarget"/>.
+    /// </summary>
+    /// <param name="logLevel">The level/severity of the log event.</param>
+    /// <param name="logEvent">The log event.</param>
+    public override void Write(LogLevel logLevel, LogEventInfo logEvent)
+    {
+        base.Write(logLevel, logEvent);
 
-            var format = config.GetFormat(logLevel);
+        var format = config.GetFormat(logLevel);
 
-            var builder = new StringBuilder();
-            builder.Append("[color=");
-            builder.Append(format.TextColor.ToHexArgb());
-            builder.Append("]");
-            builder.Append(lineBuffer.Last.Value);
-            builder.Append("[/color]");
+        var builder = new StringBuilder();
+        builder.Append("[color=");
+        builder.Append(format.TextColor.ToHexArgb());
+        builder.Append("]");
+        builder.Append(lineBuffer.Last.Value);
+        builder.Append("[/color]");
 
-            lineBuffer.Last.Value = builder.ToString();
-        }
+        lineBuffer.Last.Value = builder.ToString();
     }
 }

--- a/Godot.Logging/Targets/FileTarget.cs
+++ b/Godot.Logging/Targets/FileTarget.cs
@@ -1,37 +1,36 @@
-namespace Godot.Logging.Targets
+namespace Godot.Logging.Targets;
+
+public class FileTarget : LogTarget
 {
-    public class FileTarget : LogTarget
+    private FileAccess file;
+    private string filename;
+
+    /// <summary>
+    /// The filename of the file to write teh log contents to.
+    /// </summary>
+    public string FileName => filename;
+
+    /// <summary>
+    /// Default Constructor.
+    /// </summary>
+    /// <param name="name">The name of the <see cref="LogTarget"/>.</param>
+    /// <param name="filename">The filename of the file to write the log contents to.</param>
+    public FileTarget(string name, string filename) : base(name)
     {
-        private FileAccess file;
-        private string filename;
+        this.filename = filename;
 
-        /// <summary>
-        /// The filename of the file to write teh log contents to.
-        /// </summary>
-        public string FileName => filename;
+        file = FileAccess.Open(filename, FileAccess.ModeFlags.Write);
+    }
 
-        /// <summary>
-        /// Default Constructor.
-        /// </summary>
-        /// <param name="name">The name of the <see cref="LogTarget"/>.</param>
-        /// <param name="filename">The filename of the file to write the log contents to.</param>
-        public FileTarget(string name, string filename) : base(name)
-        {
-            this.filename = filename;
+    /// <summary>
+    /// Writes a log event to the <see cref="LogTarget"/>.
+    /// </summary>
+    /// <param name="logLevel">The level/severity of the log event.</param>
+    /// <param name="logEvent">The log event.</param>
+    public override void Write(LogLevel logLevel, LogEventInfo logEvent)
+    {
+        string outputText = FormatLogText(logLevel, logEvent);
 
-            file = FileAccess.Open(filename, FileAccess.ModeFlags.Write);
-        }
-
-        /// <summary>
-        /// Writes a log event to the <see cref="LogTarget"/>.
-        /// </summary>
-        /// <param name="logLevel">The level/severity of the log event.</param>
-        /// <param name="logEvent">The log event.</param>
-        public override void Write(LogLevel logLevel, LogEventInfo logEvent)
-        {
-            string outputText = FormatLogText(logLevel, logEvent);
-
-            file.StoreLine(outputText);
-        }
+        file.StoreLine(outputText);
     }
 }

--- a/Godot.Logging/Targets/GDPrintTarget.cs
+++ b/Godot.Logging/Targets/GDPrintTarget.cs
@@ -1,6 +1,6 @@
-using Godot;
-
 namespace Godot.Logging.Targets;
+
+using Godot;
 
 /// <summary>
 /// A <see cref="LogTarget"/> that uses the GD.Print methods

--- a/Godot.Logging/Targets/GDPrintTarget.cs
+++ b/Godot.Logging/Targets/GDPrintTarget.cs
@@ -1,45 +1,44 @@
 using Godot;
 
-namespace Godot.Logging.Targets
+namespace Godot.Logging.Targets;
+
+/// <summary>
+/// A <see cref="LogTarget"/> that uses the GD.Print methods
+/// as a log output source.
+/// </summary>
+public class GDPrintTarget : LogTarget
 {
     /// <summary>
-    /// A <see cref="LogTarget"/> that uses the GD.Print methods
-    /// as a log output source.
+    /// Default constructor for a <see cref="GDPrintTarget"/>.
     /// </summary>
-    public class GDPrintTarget : LogTarget
+    /// <param name="name">The name to give the target within the logging system.</param>
+    public GDPrintTarget(string name) : base(name)
     {
-        /// <summary>
-        /// Default constructor for a <see cref="GDPrintTarget"/>.
-        /// </summary>
-        /// <param name="name">The name to give the target within the logging system.</param>
-        public GDPrintTarget(string name) : base(name)
+
+    }
+
+    /// <summary>
+    /// Writes a log event to the <see cref="LogTarget"/>.
+    /// </summary>
+    /// <param name="logLevel">The level/severity of the log event.</param>
+    /// <param name="logEvent">The log event.</param>
+    public override void Write(LogLevel logLevel, LogEventInfo logEvent)
+    {
+        string outputText = FormatLogText(logLevel, logEvent);
+
+        switch (logLevel)
         {
-
-        }
-
-        /// <summary>
-        /// Writes a log event to the <see cref="LogTarget"/>.
-        /// </summary>
-        /// <param name="logLevel">The level/severity of the log event.</param>
-        /// <param name="logEvent">The log event.</param>
-        public override void Write(LogLevel logLevel, LogEventInfo logEvent)
-        {
-            string outputText = FormatLogText(logLevel, logEvent);
-
-            switch (logLevel)
-            {
-                case LogLevel.Debug:
-                case LogLevel.Info:
-                case LogLevel.Command:
-                    GD.Print(outputText);
-                    break;
-                case LogLevel.Warn:
-                    GD.PushWarning(outputText);
-                    break;
-                case LogLevel.Error:
-                    GD.PrintErr(outputText);
-                    break;
-            }
+            case LogLevel.Debug:
+            case LogLevel.Info:
+            case LogLevel.Command:
+                GD.Print(outputText);
+                break;
+            case LogLevel.Warn:
+                GD.PushWarning(outputText);
+                break;
+            case LogLevel.Error:
+                GD.PrintErr(outputText);
+                break;
         }
     }
 }

--- a/Godot.Logging/Targets/LogTarget.cs
+++ b/Godot.Logging/Targets/LogTarget.cs
@@ -1,65 +1,64 @@
 using System.Collections.Generic;
 
-namespace Godot.Logging.Targets
+namespace Godot.Logging.Targets;
+
+/// <summary>
+/// Base class for a log target.
+/// </summary>
+public abstract class LogTarget
 {
+    protected List<LogLevel> supportedLevels;
+    protected LogConfiguration config;
+
     /// <summary>
-    /// Base class for a log target.
+    /// The name of the <see cref="LogTarget"/>.
     /// </summary>
-    public abstract class LogTarget
+    public string Name
     {
-        protected List<LogLevel> supportedLevels;
-        protected LogConfiguration config;
+        get;
+        private set;
+    }
 
-        /// <summary>
-        /// The name of the <see cref="LogTarget"/>.
-        /// </summary>
-        public string Name
-        {
-            get;
-            private set;
-        }
+    /// <summary>
+    /// Default constructor for <see cref="LogTarget"/>.
+    /// </summary>
+    public LogTarget(string name)
+    {
+        supportedLevels = new List<LogLevel>();
+        Name = name;
+    }
 
-        /// <summary>
-        /// Default constructor for <see cref="LogTarget"/>.
-        /// </summary>
-        public LogTarget(string name)
-        {
-            supportedLevels = new List<LogLevel>();
-            Name = name;
-        }
+    /// <summary>
+    /// Writes a log event to the <see cref="LogTarget"/>.
+    /// </summary>
+    /// <param name="logLevel">The level/severity of the log event.</param>
+    /// <param name="logEvent">The log event.</param>
+    public abstract void Write(LogLevel logLevel, LogEventInfo logEvent);
 
-        /// <summary>
-        /// Writes a log event to the <see cref="LogTarget"/>.
-        /// </summary>
-        /// <param name="logLevel">The level/severity of the log event.</param>
-        /// <param name="logEvent">The log event.</param>
-        public abstract void Write(LogLevel logLevel, LogEventInfo logEvent);
+    /// <summary>
+    /// Formats the log text based on <see cref="FormatRule"/> associated with the <see cref="LogConfiguration"/>.
+    /// </summary>
+    /// <param name="logLevel">The level/severity of the log event.</param>
+    /// <param name="logEvent">The log event.</param>
+    /// <returns>A formatted string.</returns>
+    protected string FormatLogText(LogLevel logLevel, LogEventInfo logEvent)
+    {
+        var format = config.GetFormat(logLevel);
 
-        /// <summary>
-        /// Formats the log text based on <see cref="FormatRule"/> associated with the <see cref="LogConfiguration"/>.
-        /// </summary>
-        /// <param name="logLevel">The level/severity of the log event.</param>
-        /// <param name="logEvent">The log event.</param>
-        /// <returns>A formatted string.</returns>
-        protected string FormatLogText(LogLevel logLevel, LogEventInfo logEvent)
-        {
-            var format = config.GetFormat(logLevel);
+        string output = (string)format.FormatText.Clone();
+        output = output.Replace("${level}", logLevel.ToString());
+        output = output.Replace("${classname}", logEvent.ClassName);
+        output = output.Replace("${methodname}", logEvent.MethodName);
+        output = output.Replace("${message}", logEvent.Message);
+        return output;
+    }
 
-            string output = (string)format.FormatText.Clone();
-            output = output.Replace("${level}", logLevel.ToString());
-            output = output.Replace("${classname}", logEvent.ClassName);
-            output = output.Replace("${methodname}", logEvent.MethodName);
-            output = output.Replace("${message}", logEvent.Message);
-            return output;
-        }
-
-        /// <summary>
-        /// Passes the <see cref="LogConfiguration"/> to the <see cref="LogTarget"/>.
-        /// </summary>
-        /// <param name="cfg">The LogConfiguration.</param>
-        internal void SetConfiguration(LogConfiguration cfg)
-        {
-            config = cfg;
-        }
+    /// <summary>
+    /// Passes the <see cref="LogConfiguration"/> to the <see cref="LogTarget"/>.
+    /// </summary>
+    /// <param name="cfg">The LogConfiguration.</param>
+    internal void SetConfiguration(LogConfiguration cfg)
+    {
+        config = cfg;
     }
 }

--- a/Godot.Logging/Targets/LogTarget.cs
+++ b/Godot.Logging/Targets/LogTarget.cs
@@ -1,6 +1,6 @@
-using System.Collections.Generic;
-
 namespace Godot.Logging.Targets;
+
+using System.Collections.Generic;
 
 /// <summary>
 /// Base class for a log target.

--- a/Godot.Logging/Targets/MemoryTarget.cs
+++ b/Godot.Logging/Targets/MemoryTarget.cs
@@ -1,62 +1,61 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Godot.Logging.Targets
+namespace Godot.Logging.Targets;
+
+/// <summary>
+/// In-memory log target.
+/// </summary>
+public class MemoryTarget : LogTarget
 {
+    protected LinkedList<string> lineBuffer;
+    protected int maxLineCount;
+
     /// <summary>
-    /// In-memory log target.
+    /// Default constructor for a <see cref="MemoryTarget"/>.
     /// </summary>
-    public class MemoryTarget : LogTarget
+    /// <param name="name">The name to give the target within the logging system.</param>
+    public MemoryTarget(string name) : base(name)
     {
-        protected LinkedList<string> lineBuffer;
-        protected int maxLineCount;
+        lineBuffer = new LinkedList<string>();
+        maxLineCount = int.MaxValue;
+    }
 
-        /// <summary>
-        /// Default constructor for a <see cref="MemoryTarget"/>.
-        /// </summary>
-        /// <param name="name">The name to give the target within the logging system.</param>
-        public MemoryTarget(string name) : base(name)
-        {
-            lineBuffer = new LinkedList<string>();
-            maxLineCount = int.MaxValue;
-        }
+    /// <summary>
+    /// Constructor for a <see cref="MemoryTarget"/> that allows setting
+    /// the size of the buffer (in lines).
+    /// </summary>
+    /// <param name="name">The name to give the target within the logging system.</param>
+    /// <param name="bufferSize">The number log entries to be kept in memory.</param>
+    public MemoryTarget(string name, int bufferSize) : this(name)
+    {
+        maxLineCount = bufferSize;
+    }
 
-        /// <summary>
-        /// Constructor for a <see cref="MemoryTarget"/> that allows setting
-        /// the size of the buffer (in lines).
-        /// </summary>
-        /// <param name="name">The name to give the target within the logging system.</param>
-        /// <param name="bufferSize">The number log entries to be kept in memory.</param>
-        public MemoryTarget(string name, int bufferSize) : this(name)
-        {
-            maxLineCount = bufferSize;
-        }
+    /// <summary>
+    /// Writes a log event to the <see cref="LogTarget"/>.
+    /// </summary>
+    /// <param name="logLevel">The level/severity of the log event.</param>
+    /// <param name="logEvent">The log event.</param>
+    public override void Write(LogLevel logLevel, LogEventInfo logEvent)
+    {
+        string outputText = FormatLogText(logLevel, logEvent);
 
-        /// <summary>
-        /// Writes a log event to the <see cref="LogTarget"/>.
-        /// </summary>
-        /// <param name="logLevel">The level/severity of the log event.</param>
-        /// <param name="logEvent">The log event.</param>
-        public override void Write(LogLevel logLevel, LogEventInfo logEvent)
-        {
-            string outputText = FormatLogText(logLevel, logEvent);
+        if (lineBuffer.Count == maxLineCount)
+            lineBuffer.RemoveFirst();
 
-            if (lineBuffer.Count == maxLineCount)
-                lineBuffer.RemoveFirst();
+        lineBuffer.AddLast(outputText);
+    }
 
-            lineBuffer.AddLast(outputText);
-        }
-
-        /// <summary>
-        /// Returns the entire log as a string.
-        /// </summary>
-        /// <returns>The log as a string.</returns>
-        public override string ToString()
-        {
-            var builder = new StringBuilder();
-            foreach (var line in lineBuffer)
-                builder.AppendLine(line);
-            return builder.ToString();
-        }
+    /// <summary>
+    /// Returns the entire log as a string.
+    /// </summary>
+    /// <returns>The log as a string.</returns>
+    public override string ToString()
+    {
+        var builder = new StringBuilder();
+        foreach (var line in lineBuffer)
+            builder.AppendLine(line);
+        return builder.ToString();
     }
 }

--- a/Godot.Logging/Targets/MemoryTarget.cs
+++ b/Godot.Logging/Targets/MemoryTarget.cs
@@ -1,7 +1,7 @@
+namespace Godot.Logging.Targets;
+
 using System.Collections.Generic;
 using System.Text;
-
-namespace Godot.Logging.Targets;
 
 /// <summary>
 /// In-memory log target.


### PR DESCRIPTION
- Converted all scripts to use file-scoped namespaces
- All local usings are defined after namespace to ensure these always take priority over usings with the global modifier. That is if you plan to use [global usings](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive#global-modifier) in the future